### PR TITLE
pisa

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ python -m benchmark.on_pyserini -d "<dataset>"
 
 # For elastic, After starting the server, run:
 python -m benchmark.on_elastic -d "<dataset>"
+
+# for PISA
+python -m benchmark.on_pisa -d "<dataset>"
 ```
 
 where `<dataset>` is the name of the dataset to be used. 
@@ -89,24 +92,23 @@ The shorthands used are:
 
 ### Queries per second
 
-| dataset          |   BM25S |    ES |   PSRN |     PT |   Rank |
-|:-----------------|--------:|------:|-------:|-------:|-------:|
-| arguana          |  573.91 | 13.67 |  11.95 | 110.51 |   2    |
-| climate-fever    |   13.09 |  4.02 |   8.06 | OOM    |   0.03 |
-| cqadupstack      |  170.91 | 13.38 | DNT    | OOM    |   0.77 |
-| dbpedia-entity   |   13.44 | 10.68 |  12.69 | OOM    |   0.11 |
-| fever            |   20.19 |  7.45 |  10.52 | OOM    |   0.06 |
-| fiqa             |  717.78 | 16.96 |  12.51 |  20.52 |   4.46 |
-| hotpotqa         |   20.88 |  7.11 |  10.41 | OOM    |   0.04 |
-| msmarco          |   12.2  | 11.88 |  11.01 | OOM    |   0.07 |
-| nfcorpus         | 1196.16 | 45.84 |  32.94 | 256.67 | 224.66 |
-| nq               |   41.85 | 12.16 |  11.04 | OOM    |   0.1  |
-| quora            |  272.04 | 21.8  |  15.58 |   6.49 |   1.18 |
-| scidocs          |  767.05 | 17.93 |  14.1  |  41.34 |   9.01 |
-| scifact          | 1317.12 | 20.81 |  15.02 | 184.3  |  47.6  |
-| trec-covid       |   85.64 |  7.34 |   8.53 |   3.73 |   1.48 |
-| webis-touche2020 |   60.59 | 13.53 |  12.36 | OOM    |   1.1  |
-
+| dataset          |   PISA  |   BM25S |    ES |   PSRN |     PT |   Rank |
+|:-----------------|--------:|--------:|------:|-------:|-------:|-------:|
+| arguana          |  128.01 |  573.91 | 13.67 |  11.95 | 110.51 |   2    |
+| climate-fever    |   25.66 |   13.09 |  4.02 |   8.06 | OOM    |   0.03 |
+| cqadupstack      |  281.65 |  170.91 | 13.38 | DNT    | OOM    |   0.77 |
+| dbpedia-entity   |  114.05 |   13.44 | 10.68 |  12.69 | OOM    |   0.11 |
+| fever            |   60.76 |   20.19 |  7.45 |  10.52 | OOM    |   0.06 |
+| fiqa             |  546.61 |  717.78 | 16.96 |  12.51 |  20.52 |   4.46 |
+| hotpotqa         |   39.70 |   20.88 |  7.11 |  10.41 | OOM    |   0.04 |
+| msmarco          |  125.18 |   12.2  | 11.88 |  11.01 | OOM    |   0.07 |
+| nfcorpus         | 2639.38 | 1196.16 | 45.84 |  32.94 | 256.67 | 224.66 |
+| nq               |  117.34 |   41.85 | 12.16 |  11.04 | OOM    |   0.1  |
+| quora            |  528.45 |  272.04 | 21.8  |  15.58 |   6.49 |   1.18 |
+| scidocs          |  678.06 |  767.05 | 17.93 |  14.1  |  41.34 |   9.01 |
+| scifact          | 1100.60 | 1317.12 | 20.81 |  15.02 | 184.3  |  47.6  |
+| trec-covid       |  140.92 |   85.64 |  7.34 |   8.53 |   3.73 |   1.48 |
+| webis-touche2020 |  201.19 |   60.59 | 13.53 |  12.36 | OOM    |   1.1  |
 
 
 Notes:
@@ -116,46 +118,47 @@ Notes:
 <details>
 <summary>Show BM25S & ES multi-threaded (4T) performance (Q/s)</summary>
 
-| dataset          |   BM25S |    ES |
-|:-----------------|--------:|------:|
-| arguana          |  211    | 33.37 |
-| climate-fever    |   22.06 |  8.13 |
-| cqadupstack      |  248.87 | 27.76 |
-| dbpedia-entity   |   26.18 | 15.49 |
-| fever            |   47.03 | 14.07 |
-| fiqa             |  449.82 | 36.33 |
-| hotpotqa         |   45.02 | 10.35 |
-| msmarco          |   21.64 | 18.19 |
-| nfcorpus         |  784.24 | 81.07 |
-| nq               |   77.49 | 19.18 |
-| quora            |  308.58 | 43.02 |
-| scidocs          |  614.23 | 46.36 |
-| scifact          |  645.88 | 50.93 |
-| trec-covid       |  100.88 | 13.5  |
-| webis-touche2020 |  202.39 | 26.55 |
+| dataset          |    PISA |   BM25S |    ES |
+|:-----------------|--------:|--------:|------:|
+| arguana          |  311.00 |  211    | 33.37 |
+| climate-fever    |   69.89 |   22.06 |  8.13 |
+| cqadupstack      |  694.82 |  248.87 | 27.76 |
+| dbpedia-entity   |  294.66 |   26.18 | 15.49 |
+| fever            |  166.77 |   47.03 | 14.07 |
+| fiqa             | 1240.22 |  449.82 | 36.33 |
+| hotpotqa         |  109.44 |   45.02 | 10.35 |
+| msmarco          |  340.29 |   21.64 | 18.19 |
+| nfcorpus         | 3188.22 |  784.24 | 81.07 |
+| nq               |  312.09 |   77.49 | 19.18 |
+| quora            | 1534.93 |  308.58 | 43.02 |
+| scidocs          | 1461.20 |  614.23 | 46.36 |
+| scifact          | 2620.73 |  645.88 | 50.93 |
+| trec-covid       |  268.96 |  100.88 | 13.5  |
+| webis-touche2020 |  297.79 |  202.39 | 26.55 |
+
 
 </details>
 
 <details>
 <summary>Show normalized table wrt Rank-BM25</summary>
 
-| dataset          |   BM25S |     ES |   PSRN |     PT |   Rank |
-|:-----------------|--------:|-------:|-------:|-------:|-------:|
-| arguana          |  286.96 |   6.84 |   5.98 |  55.26 |      1 |
-| climate-fever    |  436.33 | 134    | 268.67 | nan    |      1 |
-| cqadupstack      |  221.96 |  17.38 | nan    | nan    |      1 |
-| dbpedia-entity   |  122.18 |  97.09 | 115.36 | nan    |      1 |
-| fever            |  336.5  | 124.17 | 175.33 | nan    |      1 |
-| fiqa             |  160.94 |   3.8  |   2.8  |   4.6  |      1 |
-| hotpotqa         |  522    | 177.75 | 260.25 | nan    |      1 |
-| msmarco          |  174.29 | 169.71 | 157.29 | nan    |      1 |
-| nfcorpus         |    5.32 |   0.2  |   0.15 |   1.14 |      1 |
-| nq               |  418.5  | 121.6  | 110.4  | nan    |      1 |
-| quora            |  230.54 |  18.47 |  13.2  |   5.5  |      1 |
-| scidocs          |   85.13 |   1.99 |   1.56 |   4.59 |      1 |
-| scifact          |   27.67 |   0.44 |   0.32 |   3.87 |      1 |
-| trec-covid       |   57.86 |   4.96 |   5.76 |   2.52 |      1 |
-| webis-touche2020 |   55.08 |  12.3  |  11.24 | nan    |      1 |
+| dataset          |    PISA |   BM25S |     ES |   PSRN |     PT |   Rank |
+|:-----------------|--------:|--------:|-------:|-------:|-------:|-------:|
+| arguana          |   64.01 |  286.96 |   6.84 |   5.98 |  55.26 |      1 |
+| climate-fever    |  855.33 |  436.33 | 134    | 268.67 | nan    |      1 |
+| cqadupstack      |  365.78 |  221.96 |  17.38 | nan    | nan    |      1 |
+| dbpedia-entity   | 1036.82 |  122.18 |  97.09 | 115.36 | nan    |      1 |
+| fever            | 1012.67 |  336.5  | 124.17 | 175.33 | nan    |      1 |
+| fiqa             |  122.56 |  160.94 |   3.8  |   2.8  |   4.6  |      1 |
+| hotpotqa         |  992.50 |  522    | 177.75 | 260.25 | nan    |      1 |
+| msmarco          | 1788.29 |  174.29 | 169.71 | 157.29 | nan    |      1 |
+| nfcorpus         |   11.75 |    5.32 |   0.2  |   0.15 |   1.14 |      1 |
+| nq               | 1173.40 |  418.5  | 121.6  | 110.4  | nan    |      1 |
+| quora            |  447.84 |  230.54 |  18.47 |  13.2  |   5.5  |      1 |
+| scidocs          |   75.26 |   85.13 |   1.99 |   1.56 |   4.59 |      1 |
+| scifact          |   23.12 |   27.67 |   0.44 |   0.32 |   3.87 |      1 |
+| trec-covid       |   95.22 |   57.86 |   4.96 |   5.76 |   2.52 |      1 |
+| webis-touche2020 |  182.90 |   55.08 |  12.3  |  11.24 | nan    |      1 |
 
 </details>
 
@@ -184,23 +187,23 @@ Notes:
 
 The following results follow the same setup as the queries/s benchmarks described above (single-core).
 
-| dataset          |    BM25S |      ES |     PSRN |      PT |     Rank |
-|:-----------------|---------:|--------:|---------:|--------:|---------:|
-| arguana          |  4314.79 | 3591.63 |  1225.18 |  638.1  |  5021.3  |
-| climate-fever    |  4364.43 | 3825.89 |  6880.42 |  nan    |  7085.51 |
-| cqadupstack      |  4800.89 | 3725.43 |   nan    |  nan    |  5370.32 |
-| dbpedia-entity   |  7576.28 | 6333.82 |  8501.7  |  nan    |  9110.36 |
-| fever            |  4921.88 | 3879.63 |  7007.5  |  nan    |  5482.64 |
-| fiqa             |  5959.25 | 4035.11 |  3735.38 |  421.51 |  6455.53 |
-| hotpotqa         |  7420.39 | 5455.6  | 10342.5  |  nan    |  9407.9  |
-| msmarco          |  7480.71 | 5391.29 |  9686.07 |  nan    | 12455.9  |
-| nfcorpus         |  3169.4  | 1688.15 |   692.05 |  442.2  |  3579.47 |
-| nq               |  6083.86 | 5742.13 |  6652.33 |  nan    |  6048.85 |
-| quora            | 28002.4  | 8189.75 | 22818.5  | 6251.26 | 47609.2  |
-| scidocs          |  4107.46 | 3008.45 |  2137.64 |  312.72 |  4232.15 |
-| scifact          |  3253.63 | 2649.57 |   880.53 |  442.61 |  3792.84 |
-| trec-covid       |  4600.14 | 2966.98 |  3768.1  |  406.37 |  4672.62 |
-| webis-touche2020 |  2971.96 | 2484.87 |  2718.41 |  nan    |  3115.96 |
+| dataset          |     PISA |    BM25S |      ES |     PSRN |      PT |     Rank |
+|:-----------------|---------:|---------:|--------:|---------:|--------:|---------:|
+| arguana          |  3608.75 |  4314.79 | 3591.63 |  1225.18 |  638.1  |  5021.3  |
+| climate-fever    |  5474.84 |  4364.43 | 3825.89 |  6880.42 |  nan    |  7085.51 |
+| cqadupstack      |  4380.73 |  4800.89 | 3725.43 |   nan    |  nan    |  5370.32 |
+| dbpedia-entity   |  9532.44 |  7576.28 | 6333.82 |  8501.7  |  nan    |  9110.36 |
+| fever            |  5633.20 |  4921.88 | 3879.63 |  7007.5  |  nan    |  5482.64 |
+| fiqa             |  4655.99 |  5959.25 | 4035.11 |  3735.38 |  421.51 |  6455.53 |
+| hotpotqa         | 10199.26 |  7420.39 | 5455.6  | 10342.5  |  nan    |  9407.9  |
+| msmarco          |  9873.08 |  7480.71 | 5391.29 |  9686.07 |  nan    | 12455.9  |
+| nfcorpus         |  2484.47 |  3169.4  | 1688.15 |   692.05 |  442.2  |  3579.47 |
+| nq               |  6923.50 |  6083.86 | 5742.13 |  6652.33 |  nan    |  6048.85 |
+| quora            | 37954.43 | 28002.4  | 8189.75 | 22818.5  | 6251.26 | 47609.2  |
+| scidocs          |  3076.90 |  4107.46 | 3008.45 |  2137.64 |  312.72 |  4232.15 |
+| scifact          |  2560.91 |  3253.63 | 2649.57 |   880.53 |  442.61 |  3792.84 |
+| trec-covid       |  4736.72 |  4600.14 | 2966.98 |  3768.1  |  406.37 |  4672.62 |
+| webis-touche2020 |  2301.53 |  2971.96 | 2484.87 |  2718.41 |  nan    |  3115.96 |
 
 #### NDCG@10
 
@@ -266,3 +269,4 @@ We use the following abbreviations for the datasets:
 * PT: [MS](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-msmarco), [CF](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-climate-fever), [FV](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-fever), [DB](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-dbpedia-entity), [HP](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-hotpotqa), [NQ](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-nq), [WT](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-webis-touche2020), [CD](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-cqadupstack), [Remaining](https://www.kaggle.com/code/xhlulu/benchmark-bm25-pt-sub-1m)
 * Rank: [DB](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-dbpedia-entity), [HP](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-hotpotqa), [CF](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-climate-fever), [FV](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-fever), [MS](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-msmarco), [NQ](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-nq), [CD](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-cqadupstack), [Remaining](https://www.kaggle.com/code/xhlulu/benchmark-rank-bm25-sub-1m)
 * PSRN: [CD](https://www.kaggle.com/code/xhlulu/benchmark-pyserini-cqadupstack), [FV](https://www.kaggle.com/code/xhlulu/benchmark-pyserini-fever), [HP](https://www.kaggle.com/code/xhlulu/benchmark-pyserini-hotpotqa), [MS](https://www.kaggle.com/code/xhlulu/benchmark-pyserini-msmarco), [DB](https://www.kaggle.com/code/xhlulu/benchmark-pyserini-dbpedia-entity), [NQ](https://www.kaggle.com/code/xhlulu/benchmark-pyserini-nq), [Remaining](https://www.kaggle.com/code/xhlulu/benchmark-pyserini-sub-1m)
+* PISA: [NQ](https://www.kaggle.com/smac2048/pisa-nq), [DB](https://www.kaggle.com/code/smac2048/pisa-dbpedia-entity), [CF](https://www.kaggle.com/code/smac2048/pisa-climate-fever), [HP](https://www.kaggle.com/code/smac2048/pisa-hotpotqa), [FV](https://www.kaggle.com/code/smac2048/pisa-fever), [MS](https://www.kaggle.com/code/smac2048/pisa-msmarco), [CD](https://www.kaggle.com/code/smac2048/pisa-cqadupstack), [Remaining](https://www.kaggle.com/code/smac2048/pisa-rest)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The shorthands used are:
 - `PSRN` for `pyserini`
 - `R-BM25` for `rank-bm25`
 - `ES` for `elasticsearch`
+- `PISA` for the [Pisa Engine](https://github.com/pisa-engine/pisa) (via the [`pyterrier_pisa`](https://github.com/terrierteam/pyterrier_pisa) Python bindings)
 - `OOM` for out-of-memory error
 - `DNT` for did not terminate (i.e. went over 12 hours)
 

--- a/benchmark/on_pisa.py
+++ b/benchmark/on_pisa.py
@@ -29,7 +29,7 @@ def format_beir_result_keys(beir_results):
 
 
 def build_pisa_index(
-    corpus_records, index_dir, n_threads=-1, stemmer="porter2", keep_stopwords=False, python_str=None, verbose=1, k1=1.2, b=0.75
+    corpus_records, index_dir, n_threads=1, stemmer="porter2", keep_stopwords=False, python_str=None, verbose=1, k1=1.2, b=0.75
 ):
     """
     Build a PISA index from a list of corpus_records.

--- a/benchmark/on_pisa.py
+++ b/benchmark/on_pisa.py
@@ -60,12 +60,7 @@ def main(dataset, save_dir="datasets", result_dir="results", n_threads=1, top_k=
     data_dir = Path(save_dir)
     data_path = beir.util.download_and_unzip(url, str(data_dir))
     if dataset == "cqadupstack":
-            # merge and clean up old files
-            if os.path.exists(f'{data_path}.zip'):
-                os.remove(f'{data_path}.zip')
             merge_cqa_dupstack(data_path)
-            for hgx in glob(f'{data_path}/*/*.jsonl'):
-                os.remove(hgx)
     
     if dataset == "msmarco":
         split = "dev"

--- a/benchmark/on_pisa.py
+++ b/benchmark/on_pisa.py
@@ -61,6 +61,8 @@ def main(dataset, save_dir="datasets", result_dir="results", n_threads=1, top_k=
     data_path = beir.util.download_and_unzip(url, str(data_dir))
     if dataset == "cqadupstack":
             # merge and clean up old files
+            if os.path.exists(f'{data_path}.zip'):
+                os.remove(f'{data_path}.zip')
             merge_cqa_dupstack(data_path)
             for hgx in glob(f'{data_path}/*/*.jsonl'):
                 os.remove(hgx)

--- a/benchmark/on_pisa.py
+++ b/benchmark/on_pisa.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import json
 import os
+from glob import glob
 from pathlib import Path
 import time
 from typing import Optional
@@ -59,7 +60,10 @@ def main(dataset, save_dir="datasets", result_dir="results", n_threads=1, top_k=
     data_dir = Path(save_dir)
     data_path = beir.util.download_and_unzip(url, str(data_dir))
     if dataset == "cqadupstack":
+            # merge and clean up old files
             merge_cqa_dupstack(data_path)
+            for hgx in glob(f'{data_path}/*/*.jsonl'):
+                os.remove(hgx)
     
     if dataset == "msmarco":
         split = "dev"

--- a/benchmark/on_pisa.py
+++ b/benchmark/on_pisa.py
@@ -1,0 +1,203 @@
+import pandas as pd
+import json
+import os
+from pathlib import Path
+import time
+from typing import Optional
+import warnings
+from functools import partial
+import subprocess
+import json
+from pathlib import Path
+import sys
+from typing import List, Dict
+import multiprocessing as mp
+
+from tqdm.auto import tqdm
+import beir.util
+from beir.datasets.data_loader import GenericDataLoader
+from beir.retrieval.evaluation import EvaluateRetrieval
+from pyterrier_pisa import PisaIndex
+import pyterrier as pt ; pt.init()
+
+from utils.beir import merge_cqa_dupstack
+
+def format_beir_result_keys(beir_results):
+    return {
+        k.split("@")[-1]: v for k, v in beir_results.items()
+    }
+
+
+def build_pisa_index(
+    corpus_records, index_dir, n_threads=-1, stemmer="porter2", keep_stopwords=False, python_str=None, verbose=1, k1=1.2, b=0.75
+):
+    """
+    Build a PISA index from a list of corpus_records.
+    """
+    if n_threads < 1:
+        import multiprocessing
+
+        n_threads = multiprocessing.cpu_count()
+
+    if stemmer in [None, False]:
+        stemmer = "none"
+
+    index = PisaIndex(str(index_dir), stemmer=stemmer, threads=n_threads)
+
+    index.indexer(mode="overwrite").index(corpus_records)
+
+    return index.bm25(k1=k1, b=b, threads=n_threads)
+
+
+def main(dataset, save_dir="datasets", result_dir="results", n_threads=1, top_k=1000, k1=1.2, b=0.75):
+    warnings.filterwarnings("ignore", category=UserWarning)
+
+    #### Download dataset and unzip the dataset
+    base_url = "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip"
+
+    url = base_url.format(dataset)
+    data_dir = Path(save_dir)
+    data_path = beir.util.download_and_unzip(url, str(data_dir))
+    if dataset == "cqadupstack":
+            merge_cqa_dupstack(data_path)
+    
+    if dataset == "msmarco":
+        split = "dev"
+    else:
+        split = "test"
+    
+    corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split=split)
+    
+    num_docs = len(corpus)
+    corpus_records = [
+        {'docno': key, 'text': val['title'] + " " + val['text']} for key, val in corpus.items()
+    ]
+    del corpus
+
+    query_frame = pd.DataFrame(queries.items(), columns=['qid', 'query'])
+
+    t0 = time.time()
+    bm25 = build_pisa_index(corpus_records=corpus_records, index_dir=data_dir/dataset/'index.pisa', n_threads=n_threads, k1=k1, b=b)
+    time_index = time.time() - t0
+
+    print('='*50)
+    print(f"[PISA] Index: {time_index:.4f}s ({num_docs / time_index:.2f}/s)")
+
+    # now, run query and get score as well
+    
+    # lucene_analyzer = get_lucene_analyzer(stemmer='snowball', stopwords=True)
+    # analyzer = Analyzer(lucene_analyzer)
+
+    # ################### BEIR BENCHMARKING HERE ###################
+    # results's format: {query_id: {doc_id: score, doc_id: score, ...}, ...}
+    k_values = [1,10,100,1000]
+
+    t0 = time.time()
+    bm25.num_results = top_k
+    bm25.threads = n_threads
+    hits = bm25(query_frame)
+    time_search = time.time() - t0
+    print(f"[PISA] Query: {time_search:.4f}s ({len(query_frame) / time_search:.2f}/s)")
+    print('-'*50)
+
+    results = {}
+    for qid, docno, score in hits[['qid', 'docno', 'score']].itertuples(index=False):
+        if qid not in results:
+            results[qid] = {}
+        results[qid][docno] = score
+
+    ndcg, _map, recall, precision = EvaluateRetrieval.evaluate(qrels, results, k_values)
+    print(ndcg)
+    print(recall)
+    print(precision)
+
+    # Save everything to json
+    save_dict = {
+        "model": "pisa",
+        "dataset": dataset,
+        "stemmer": "porter",
+        "tokenizer": "pisa",
+        "method": "pisa",
+        "k1": k1,
+        "b": b,
+        "date": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "n_threads": n_threads,
+        "top_k": top_k,
+        "stats": {
+            "num_docs": num_docs,
+            "num_queries": len(query_frame),
+        },
+        "timing": {
+            "index": {"elapsed": round(time_index, 4)},
+            "query": {"elapsed": round(time_search, 4)},
+        },
+        "ndcg": format_beir_result_keys(ndcg),
+        "map": format_beir_result_keys(_map),
+        "recall": format_beir_result_keys(recall),
+        "precision": format_beir_result_keys(precision),
+    }
+
+    result_dir = Path(result_dir) / "pisa"
+    result_dir.mkdir(parents=True, exist_ok=True)
+    save_path = Path(result_dir) / f"{dataset}-{os.urandom(8).hex()}.json"
+    with open(save_path, "w") as f:
+        json.dump(save_dict, f, indent=2)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Benchmark pisa on a dataset.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-d", "--dataset",
+        type=str,
+        default="fiqa",
+        help="Dataset to benchmark on.",
+    )
+
+    parser.add_argument(
+        "-n", "--n_threads",
+        type=int,
+        default=1,
+        help="Number of jobs to run in parallel.",
+    )
+
+    parser.add_argument(
+        "--top_k",
+        type=int,
+        default=1000,
+        help="Number of top-k documents to retrieve.",
+    )
+    parser.add_argument(
+        "--save_dir",
+        type=str,
+        default="datasets",
+        help="Directory to download datasets.",
+    )
+    parser.add_argument(
+        "--result_dir",
+        type=str,
+        default="results",
+        help="Directory to save results.",
+    )
+
+    parser.add_argument(
+        "--k1",
+        type=float,
+        default=1.2,
+        help="BM25 k1 parameter.",
+    )
+
+    parser.add_argument(
+        "--b",
+        type=float,
+        default=0.75,
+        help="BM25 b parameter.",
+    )
+
+    kwargs = vars(parser.parse_args())
+    main(**kwargs)

--- a/requirements-pisa.txt
+++ b/requirements-pisa.txt
@@ -1,0 +1,2 @@
+pyterrier_pisa
+-r requirements.txt


### PR DESCRIPTION
Adding [PISA](https://github.com/pisa-engine/pisa) to the mix!

I haven't tested all the evaluations exhaustively on Kaggle yet, but it looks like it can provide pretty substantial speedups on as datasets get larger, likely due to its dynamic pruning.

QPS (PISA are my measurements on Kaggle, others are from the README)

Single Thread:

| Dataset | Query QPS | Index DPS |
|-----|-----|-----|
| `arguana` | 128.01 | 3608.75 |
| `climate-fever` | 25.66 | 5474.84 |
| `cqadupstack` | 281.65 | 4380.73 |
| `dbpedia-entity` | 114.05 | 9532.44 |
| `fever` | 60.76 | 5633.20 |
| `fiqa` | 546.61 | 4655.99 |
| `hotpotqa` | 39.70 | 10199.26 |
| `msmarco` | 125.18 | 9873.08 |
| `nfcorpus` | 2639.38 | 2484.47 |
| `nq` | 117.34 | 6923.50 |
| `quora` | 528.45 | 37954.43 |
| `scidocs` | 678.06 | 3076.90 |
| `scifact` | 1100.60 | 2560.91 |
| `trec-covid` | 140.92 | 4736.72 |
| `webis-touche2020` | 201.19 | 2301.53 |


Multi-Thread:

| Dataset | Query QPS | Index DPS |
|-----|-----|-----|
| `arguana` | 311.00 | 3523.65 |
| `climate-fever` | 69.89 | 9034.65 |
| `cqadupstack` | 694.82 | 6587.47 |
| `dbpedia-entity` | 294.66 | 14742.73 |
| `fever` | 166.77 | 9156.45 |
| `fiqa` | 1240.22 | 4539.39 |
| `hotpotqa` | 109.44 | 15827.75 |
| `msmarco` | 340.29 | 16117.84 |
| `nfcorpus` | 3188.22 | 2506.77 |
| `nq` | 312.09 | 11571.51 |
| `quora` | 1534.93 | 73437.22 |
| `scidocs` | 1461.20 | 3127.49 |
| `scifact` | 2620.73 | 1695.45 |
| `trec-covid` | 268.96 | 4687.50 |
| `webis-touche2020` | 297.79 | 3317.11 |

Notebooks: 
 - [NQ](https://www.kaggle.com/smac2048/pisa-nq)
 - [dppedia-entity](https://www.kaggle.com/code/smac2048/pisa-dbpedia-entity)
 - [climate-fever](https://www.kaggle.com/code/smac2048/pisa-climate-fever)
 - [hotpotqa](https://www.kaggle.com/code/smac2048/pisa-hotpotqa/notebook)
 - [fever](https://www.kaggle.com/code/smac2048/pisa-fever)
 - [msmarco](https://www.kaggle.com/code/smac2048/pisa-msmarco)
 - [cqadupstack](https://www.kaggle.com/code/smac2048/pisa-cqadupstack)
 - [remainder](https://www.kaggle.com/code/smac2048/pisa-rest)

<details>
<summary>Expand for Kaggle notebook code to run</summary>

```
!git clone https://github.com/seanmacavaney/bm25-benchmarks
%cd bm25-benchmarks
%pip install -r requirements-pisa.txt
%env JAVA_HOME=/usr/lib/jvm/default-java/
!python -m benchmark.on_pisa -d msmarco
```

</details>