### PR TITLE
Update NDCG and Recall@1000 results for PISA (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ elasticsearch-*/
 multicore_results/
 analysis/out/multicore
 venv-*
+comparison_results
+analysis/out
+analysis/comparison_results

--- a/README.md
+++ b/README.md
@@ -26,23 +26,7 @@ where `<dataset>` is the name of the dataset to be used.
 
 ### Available datasets
 
-The available datasets are public BEIR datasets:
-- `trec-covid`
-- `nfcorpus`
-- `fiqa`
-- `arguana`
-- `webis-touche2020`
-- `quora`
-- `scidocs`
-- `scifact`
-- `cqadupstack`
-- `nq`
-- `msmarco`
-- `hotpotqa`
-- `dbpedia-entity`
-- `fever`
-- `climate-fever`
-
+The available datasets are public BEIR datasets: `trec-covid`, `nfcorpus`, `fiqa`, `arguana`, `webis-touche2020`, `quora`, `scidocs`, `scifact`, `cqadupstack`, `nq`, `msmarco`, `hotpotqa`, `dbpedia-entity`, `fever`, `climate-fever`, 
 ### Sampling during benchmarking
 
 For `rank-bm25`, due to the long runtime, we can sample queries
@@ -208,8 +192,11 @@ The following results follow the same setup as the queries/s benchmarks describe
 
 #### NDCG@10
 
+We use abbreviations for datasets of BEIR benchmarks.
 
-We use the following abbreviations for the datasets:
+<details>
+<summary>Click to show dataset abbreviations</summary>
+
 - `AG` for arguana
 - `CD` for cqadupstack
 - `CF` for climate-fever
@@ -226,6 +213,8 @@ We use the following abbreviations for the datasets:
 - `TC` for trec-covid
 - `WT` for webis-touche2020
 
+</details>
+
 
 |   k1 |   b | method    |   Avg. |   AG | CD   | CF   | DB   |   FQ | FV   | HP   | MS   |   NF | NQ   |   QR |   SD |   SF |   TC | WT   |
 |-----:|----:|:----------|-------:|-----:|:-----|:-----|:-----|-----:|:-----|:-----|:-----|-----:|:-----|-----:|-----:|-----:|-----:|:-----|
@@ -240,6 +229,8 @@ We use the following abbreviations for the datasets:
 |  1.5 | 0.75 | PSRN      |   40.0 | 48.4 | 29.8 | 14.2 | 30.0 | 25.3 | 50.0 | 57.6 | 22.1 | 32.6 | 28.6 | 80.6 | 15.6 | 68.8 | 63.4 | 33.5 |
 |  1.5 | 0.75 | PT        |   45.0 | 44.9 | --   | --   | --   | 22.5 | --   | --   | --   | 31.9 | --   | 75.1 | 14.7 | 67.8 | 58.0 | --   |
 |  1.5 | 0.75 | Rank      |   39.6 | 49.5 | 29.6 | 13.6 | 29.9 | 25.3 | 49.3 | 58.1 | 21.1 | 32.1 | 28.5 | 80.3 | 15.8 | 68.5 | 60.1 | 32.9 |
+|  1.2 | 0.75 | PISA      | 38.8   | 41.2 | 27.8 | 13.8               | 30.6 | 24.6 | 49.1 | 58.1 | 22.6 | 34.4 | 28.2 | 72   | 15.7 | 68.8 | 63.7 | 31.1 |
+
 
 #### Recall@1000
 
@@ -256,6 +247,8 @@ We use the following abbreviations for the datasets:
 |  1.5 | 0.75 | PSRN      |   76.7 | 99.2 | 74.2 | 58.7 | 66.2 | 76.7 | 94.2 | 86.4 | 85.1 | 37.1 | 89.4 | 99.6 | 57.4 | 97.7 | 41.1 | 87.2 |
 |  1.5 | 0.75 | PT        |   73.0 | 98.3 | --   | --   | --   | 72.5 | --   | --   | --   | 51.0 | --   | 98.9 | 56.0 | 97.8 | 36.3 | --   |
 |  1.5 | 0.75 | Rank      |   77.1 | 99.4 | 73.4 | 57.5 | 66.4 | 77.4 | 93.6 | 87.7 | 82.6 | 47.6 | 89.5 | 99.5 | 57.4 | 96.7 | 40.5 | 87.5 |
+|  1.2 | 0.75 | PISA      | 77.1   | 98.8 | 72.2 | 59.8              | 67.6 | 76.4 | 93.7 | 86.8 | 86.9 | 38.7 | 89.1 | 98.9 | 56.9 | 97   | 46   | 87.7 |
+
 
 #### Links
 

--- a/analysis/combine_results.py
+++ b/analysis/combine_results.py
@@ -61,6 +61,7 @@ model_abbreviations = {
     "pyserini": "PSRN",
     "rank-bm25": "Rank",
     "elastic-bm25": "ES",
+    "pisa": "PISA",
 }
 
 removed_models = [

--- a/analysis/download_comparisons.py
+++ b/analysis/download_comparisons.py
@@ -7,6 +7,7 @@ import tempfile
 import time
 
 from kaggle.api.kaggle_api_extended import KaggleApi
+from utils import kernels_output
 
 ERROR_OOM = 'Your notebook tried to allocate more memory than is available.'
 ERROR_TIMEOUT = 'Your notebook was stopped because it exceeded the max allowed execution duration.'
@@ -16,53 +17,63 @@ output_base_dir = Path("./comparison_results")
 
 # use temp folder to store results
 methods_to_nb_name = {
-    'bm25-pt': [
-        'benchmark-bm25-pt-sub-1m',
-        'benchmark-bm25-pt-cqadupstack',
-        'benchmark-bm25-pt-webis-touche2020',
-        'benchmark-bm25-pt-nq',
-        'benchmark-bm25-pt-msmarco',
-        'benchmark-bm25-pt-hotpotqa',
-        'benchmark-bm25-pt-dbpedia-entity',
-        'benchmark-bm25-pt-fever', 
-        'benchmark-bm25-pt-climate-fever', 
-    ],
-    'rank-bm25': [
-        'benchmark-rank-bm25-sub-1m',
-        'benchmark-rank-bm25-cqadupstack',
-        'benchmark-rank-bm25-nq',
-        'benchmark-rank-bm25-msmarco',
-        'benchmark-rank-bm25-hotpotqa',
-        'benchmark-rank-bm25-dbpedia-entity',
-        'benchmark-rank-bm25-fever', 
-        'benchmark-rank-bm25-climate-fever', 
-    ],
-    'bm25s': [
-        "comparing-bm25s-lucene-k1-0-9-b-0-4",
-        "comparing-bm25s-lucene",
-        "run-bm25s-k1-1-5-b-0-75",
-        "comparing-bm25s-bm25l",
-        "comparing-bm25s-bm25plus",
-        "comparing-bm25s-no-stopwords-no-stemmer",
-        "comparing-bm25s-no-stopwords",
-        "comparing-bm25s-no-stemmer",
-        "comparing-bm25s-robertson",
-        "comparing-bm25s-atire",
-        "comparing-bm25s-lucene",
-    ],
-    'elasticsearch': [
-        "run-elasticsearch-k1-1-5-b-0-75"
-    ],
-    'pyserini': [
-        'benchmark-pyserini-sub-1m',
-        'benchmark-pyserini-cqadupstack',
-        'benchmark-pyserini-nq',
-        'benchmark-pyserini-msmarco',
-        'benchmark-pyserini-hotpotqa', 
-        'benchmark-pyserini-dbpedia-entity', 
-        'benchmark-pyserini-fever',  
-        'benchmark-pyserini-climate-fever',  
-    ],
+    # 'bm25-pt': [
+    #     'xhlulu/benchmark-bm25-pt-sub-1m',
+    #     'xhlulu/benchmark-bm25-pt-cqadupstack',
+    #     'xhlulu/benchmark-bm25-pt-webis-touche2020',
+    #     'xhlulu/benchmark-bm25-pt-nq',
+    #     'xhlulu/benchmark-bm25-pt-msmarco',
+    #     'xhlulu/benchmark-bm25-pt-hotpotqa',
+    #     'xhlulu/benchmark-bm25-pt-dbpedia-entity',
+    #     'xhlulu/benchmark-bm25-pt-fever', 
+    #     'xhlulu/benchmark-bm25-pt-climate-fever', 
+    # ],
+    # 'rank-bm25': [
+    #     'xhlulu/benchmark-rank-bm25-sub-1m',
+    #     'xhlulu/benchmark-rank-bm25-cqadupstack',
+    #     'xhlulu/benchmark-rank-bm25-nq',
+    #     'xhlulu/benchmark-rank-bm25-msmarco',
+    #     'xhlulu/benchmark-rank-bm25-hotpotqa',
+    #     'xhlulu/benchmark-rank-bm25-dbpedia-entity',
+    #     'xhlulu/benchmark-rank-bm25-fever', 
+    #     'xhlulu/benchmark-rank-bm25-climate-fever', 
+    # ],
+    # 'bm25s': [
+    #     "xhlulu/comparing-bm25s-lucene-k1-0-9-b-0-4",
+    #     "xhlulu/comparing-bm25s-lucene",
+    #     "xhlulu/run-bm25s-k1-1-5-b-0-75",
+    #     "xhlulu/comparing-bm25s-bm25l",
+    #     "xhlulu/comparing-bm25s-bm25plus",
+    #     "xhlulu/comparing-bm25s-no-stopwords-no-stemmer",
+    #     "xhlulu/comparing-bm25s-no-stopwords",
+    #     "xhlulu/comparing-bm25s-no-stemmer",
+    #     "xhlulu/comparing-bm25s-robertson",
+    #     "xhlulu/comparing-bm25s-atire",
+    #     "xhlulu/comparing-bm25s-lucene",
+    # ],
+    # 'elasticsearch': [
+    #     "xhlulu/run-elasticsearch-k1-1-5-b-0-75"
+    # ],
+    # 'pyserini': [
+    #     'xhlulu/benchmark-pyserini-sub-1m',
+    #     'xhlulu/benchmark-pyserini-cqadupstack',
+    #     'xhlulu/benchmark-pyserini-nq',
+    #     'xhlulu/benchmark-pyserini-msmarco',
+    #     'xhlulu/benchmark-pyserini-hotpotqa', 
+    #     'xhlulu/benchmark-pyserini-dbpedia-entity', 
+    #     'xhlulu/benchmark-pyserini-fever',  
+    #     'xhlulu/benchmark-pyserini-climate-fever',  
+    # ],
+    "pisa": [
+        "smac2048/pisa-nq",
+        "smac2048/pisa-rest",
+        "smac2048/pisa-dbpedia-entity",
+        "smac2048/pisa-climate-fever",
+        "smac2048/pisa-hotpotqa",
+        "smac2048/pisa-fever",
+        "smac2048/pisa-msmarco",
+        "smac2048/pisa-cqadupstack",
+    ]
 }
 
 
@@ -71,11 +82,9 @@ api = KaggleApi()
 api.authenticate()
 
 for method, notebook_names in methods_to_nb_name.items():
-    for name in notebook_names:   
+    for notebook_name in notebook_names:   
         output_dir = output_base_dir / method
         output_dir.mkdir(parents=True, exist_ok=True)
-
-        notebook_name = f'{username}/{name}'
 
         try:
             status = api.kernels_status(notebook_name)
@@ -97,14 +106,14 @@ for method, notebook_names in methods_to_nb_name.items():
 
             # save the error message to the same output dir as the results, but prefix with 'error'
             t = time.strftime('%Y%m%d-%H%M%S')
-            error_file = output_dir / f'error-{name}-{t}.txt'
+            error_file = output_dir / f'error-{notebook_name.replace("/", "_")}-{t}.txt'
             with open(error_file, 'w') as f:
                 f.write(failure_message)
             continue
             
         temp_dir = tempfile.mkdtemp()
 
-        out_files = api.kernels_output(notebook_name, temp_dir)
+        out_files = kernels_output(api, notebook_name, temp_dir, allowed_patterns=['*.json'])
     
         print(f"Downloaded results for '{notebook_name}'")    
         # only save out *.json files to the output folder

--- a/analysis/requirements.txt
+++ b/analysis/requirements.txt
@@ -1,2 +1,3 @@
 kaggle
 tabulate
+pandas

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,0 +1,70 @@
+import os
+import fnmatch
+import requests
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+def kernels_output(self: KaggleApi, kernel: str, path: str, force=False, quiet=True, allowed_patterns=None):
+    """ retrieve output for a specified kernel
+            Parameters
+        ==========
+        kernel: the kernel to output
+        path: the path to pull files to on the filesystem
+        force: if output already exists, force overwrite (default False)
+        quiet: suppress verbosity (default is True)
+    """
+    if kernel is None:
+        raise ValueError('A kernel must be specified')
+    if '/' in kernel:
+        self.validate_kernel_string(kernel)
+        kernel_url_list = kernel.split('/')
+        owner_slug = kernel_url_list[0]
+        kernel_slug = kernel_url_list[1]
+    else:
+        owner_slug = self.get_config_value(self.CONFIG_NAME_USER)
+        kernel_slug = kernel
+
+    if path is None:
+        target_dir = self.get_default_download_dir('kernels', owner_slug,
+                                                    kernel_slug, 'output')
+    else:
+        target_dir = path
+
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    if not os.path.isdir(target_dir):
+        raise ValueError(
+            'You must specify a directory for the kernels output')
+
+    response = self.process_response(
+        self.kernel_output_with_http_info(owner_slug, kernel_slug))
+    outfiles = []
+    
+    for item in response['files']:
+        if allowed_patterns is not None:
+            # check if the file matches any of the patterns, following bash-style pattern matching
+            # https://docs.python.org/3/library/fnmatch.html
+            match = any(fnmatch.fnmatch(item['fileName'], pattern) for pattern in allowed_patterns)
+            if not match:
+                continue
+        
+        outfile = os.path.join(target_dir, item['fileName'])
+        outfiles.append(outfile)
+        download_response = requests.get(item['url'])
+        if force or self.download_needed(item, outfile, quiet):
+            os.makedirs(os.path.split(outfile)[0], exist_ok=True)
+            with open(outfile, 'wb') as out:
+                out.write(download_response.content)
+            if not quiet:
+                print('Output file downloaded to %s' % outfile)
+
+    log = response['log']
+    if log:
+        outfile = os.path.join(target_dir, kernel_slug + '.log')
+        outfiles.append(outfile)
+        with open(outfile, 'w') as out:
+            out.write(log)
+        if not quiet:
+            print('Kernel log downloaded to %s ' % outfile)
+
+    return outfiles

--- a/benchmark/on_pisa.py
+++ b/benchmark/on_pisa.py
@@ -21,7 +21,8 @@ from beir.retrieval.evaluation import EvaluateRetrieval
 from pyterrier_pisa import PisaIndex
 import pyterrier as pt ; pt.init()
 
-from utils.beir import merge_cqa_dupstack
+from bm25s.utils.benchmark import get_max_memory_usage, Timer
+from bm25s.utils.beir import merge_cqa_dupstack
 
 def format_beir_result_keys(beir_results):
     return {
@@ -108,6 +109,14 @@ def main(dataset, save_dir="datasets", result_dir="results", n_threads=1, top_k=
         results[qid][docno] = score
 
     ndcg, _map, recall, precision = EvaluateRetrieval.evaluate(qrels, results, k_values)
+
+
+    max_mem_gb = get_max_memory_usage("GB")
+
+    print("=" * 50)
+    print(f"Max Memory Usage: {max_mem_gb:.4f} GB")
+    print("-" * 50)
+
     print(ndcg)
     print(recall)
     print(precision)


### PR DESCRIPTION
* Update names of notebooks to download

* add pattern matching to kernels ouput function from kaggle so that only json are downloaded

* Update analysis scripts to work with PISA

* Add partial results

* Update code to average scores

* update table again

* improve readability of readme

* Fix utils import error in pisa, add memory counting

* Update r@1000 results